### PR TITLE
make lidar start and stop

### DIFF
--- a/unitree_lidar_ros2/src/unitree_lidar_ros2/include/unitree_lidar_ros2.h
+++ b/unitree_lidar_ros2/src/unitree_lidar_ros2/include/unitree_lidar_ros2.h
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <algorithm>
 #include <chrono>
+#include <thread>
 
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
@@ -35,9 +36,15 @@ public:
 
   explicit UnitreeLidarSDKNode(const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
 
-  ~UnitreeLidarSDKNode(){};
+  ~UnitreeLidarSDKNode()
+  {
+    // Make sure we set LIDAR to STANDBY mode during shutdown
+    closeLidar();
+  };
 
   void timer_callback();
+  bool initializeLidar();
+  void closeLidar();
 
 protected:
 
@@ -64,6 +71,12 @@ protected:
 
   std::string imu_frame_;
   std::string imu_topic_;
+
+  bool use_udp_;
+  std::string lidar_ip_;
+  int lidar_port_;
+  std::string local_ip_;
+  int local_port_;
 };
 
 ///////////////////////////////////////////////////////////////////
@@ -87,6 +100,11 @@ UnitreeLidarSDKNode::UnitreeLidarSDKNode(const rclcpp::NodeOptions& options)
   declare_parameter<std::string>("imu_frame", "unilidar_imu");
   declare_parameter<std::string>("imu_topic", "unilidar/imu");
   
+  declare_parameter<bool>("use_udp", false);
+  declare_parameter<std::string>("lidar_ip", "192.168.1.200");
+  declare_parameter<int>("lidar_port", 2368);
+  declare_parameter<std::string>("local_ip", "192.168.1.100");
+  declare_parameter<int>("local_port", 2369);
 
   port_ = get_parameter("port").as_string();
 
@@ -103,6 +121,12 @@ UnitreeLidarSDKNode::UnitreeLidarSDKNode(const rclcpp::NodeOptions& options)
   imu_frame_ = get_parameter("imu_frame").as_string();
   imu_topic_ = get_parameter("imu_topic").as_string();
 
+  use_udp_ = get_parameter("use_udp").as_bool();
+  lidar_ip_ = get_parameter("lidar_ip").as_string();
+  lidar_port_ = get_parameter("lidar_port").as_int();
+  local_ip_ = get_parameter("local_ip").as_string();
+  local_port_ = get_parameter("local_port").as_int();
+
   // std::cout << "port_ = " << port_ 
   //           << ", cloud_topic_ = " << cloud_topic_
   //           << ", cloud_scan_num_ = " << cloud_scan_num_
@@ -110,13 +134,55 @@ UnitreeLidarSDKNode::UnitreeLidarSDKNode(const rclcpp::NodeOptions& options)
 
   // Initialize UnitreeLidarReader
   lsdk_ = createUnitreeLidarReader();
-  lsdk_->initialize(cloud_scan_num_, port_, 2000000, rotate_yaw_bias_, 
-        range_scale_, range_bias_, range_max_, range_min_);
+  initializeLidar();
 
   // ROS2
   pub_cloud_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(cloud_topic_, 10);
   pub_imu_ = this->create_publisher<sensor_msgs::msg::Imu>(imu_topic_, 10);
   timer_ = this->create_wall_timer(std::chrono::milliseconds(1), std::bind(&UnitreeLidarSDKNode::timer_callback, this));
+}
+
+bool UnitreeLidarSDKNode::initializeLidar() {
+  int result = -1;
+  
+  if (use_udp_) {
+    RCLCPP_INFO(this->get_logger(), "Initializing LIDAR over UDP with IP: %s, port: %d", 
+                lidar_ip_.c_str(), lidar_port_);
+    result = lsdk_->initializeUDP(cloud_scan_num_, lidar_port_, lidar_ip_, 
+                                 local_port_, local_ip_, rotate_yaw_bias_,
+                                 range_scale_, range_bias_, range_max_, range_min_);
+  } else {
+    RCLCPP_INFO(this->get_logger(), "Initializing LIDAR via serial port: %s", port_.c_str());
+    result = lsdk_->initialize(cloud_scan_num_, port_, 2000000, rotate_yaw_bias_,
+                              range_scale_, range_bias_, range_max_, range_min_);
+  }
+  
+  if (result != 0) {
+    RCLCPP_ERROR(this->get_logger(), "LIDAR initialization failed with code: %d", result);
+    return false;
+  }
+  
+  // Set to normal operating mode
+  RCLCPP_INFO(this->get_logger(), "Setting LIDAR to NORMAL mode");
+  lsdk_->setLidarWorkingMode(NORMAL);
+  
+  // Wait a moment for the LIDAR to transition to normal mode
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  
+  return true;
+}
+
+void UnitreeLidarSDKNode::closeLidar() {
+  if (lsdk_ != nullptr) {
+    RCLCPP_INFO(this->get_logger(), "Setting LIDAR to STANDBY mode");
+    lsdk_->setLidarWorkingMode(STANDBY);
+    
+    // Wait a moment for the LIDAR to transition to standby mode
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    
+    delete lsdk_;
+    lsdk_ = nullptr;
+  }
 }
 
 void UnitreeLidarSDKNode::timer_callback()


### PR DESCRIPTION
This sets the setLidarWorkingMode to NORMAL  when node is started, and STANDBY when the node is destructed.  This is needed to spin up and down the Lidar.

This has been tested on x86_64 Ubuntu 24.04 ros2 jazzy