### PR TITLE
Add lidar stop code in examples and register in CMakeLists

### DIFF
--- a/unitree_lidar_sdk/CMakeLists.txt
+++ b/unitree_lidar_sdk/CMakeLists.txt
@@ -13,6 +13,11 @@ link_directories(lib/${CMAKE_SYSTEM_PROCESSOR})
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib/${CMAKE_SYSTEM_PROCESSOR})
 
+add_executable(stop
+  examples/stop.cpp
+)
+target_link_libraries(stop  libunitree_lidar_sdk.a )
+
 add_executable(example_lidar
   examples/example_lidar.cpp
 )

--- a/unitree_lidar_sdk/examples/stop.cpp
+++ b/unitree_lidar_sdk/examples/stop.cpp
@@ -1,0 +1,29 @@
+/**********************************************************************
+ Copyright (c) 2020-2023, Unitree Robotics.Co.Ltd. All rights reserved.
+***********************************************************************/
+
+#include "unitree_lidar_sdk.h"
+
+using namespace unitree_lidar_sdk;
+
+int main(){
+
+  // Initialize Lidar Object
+  UnitreeLidarReader* lreader = createUnitreeLidarReader();
+  int cloud_scan_num = 18;
+  std::string port_name = "/dev/ttyUSB0";
+
+  if ( lreader->initialize(cloud_scan_num, port_name) ){
+    printf("Unilidar initialization failed! Exit here!\n");
+    exit(-1);
+  }else{
+    printf("Unilidar initialization succeed!\n");
+  }
+
+  // Set Lidar Working Mode
+  printf("Set Lidar working mode to: STANDBY ... \n");
+  lreader->setLidarWorkingMode(STANDBY);
+  sleep(5);
+ 
+  return 0;
+}


### PR DESCRIPTION
### Summary

This PR adds code examples demonstrating how to properly stop the Unitree Lidar by setting it to STANDBY mode, and registers these examples in the CMake build system.

### Changes

- ✅ Added stop logic (setLidarWorkingMode(STANDBY)) to example source files.
- ✅ Updated `CMakeLists.txt` to compile the new/updated examples.

### Purpose

To provide a clear, working example of how to gracefully stop the lidar, which helps developers avoid leaving the sensor running after exit. Also ensures the example code is built by default.

Tested locally and builds successfully. Ubuntu 20.04
